### PR TITLE
feat(linecount): utilidad mínima + docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,3 +7,10 @@ Contiene archivos simples para que puedas practicar creación de ramas, commits,
 ## Estructura
 - `src/app.js`: contiene un script básico.
 - `data/info.txt`: contiene datos de ejemplo.
+
+## Script linecount
+
+Ejemplo de uso:
+```bash
+./scripts/linecount.sh README.md
+```

--- a/decisiones.md
+++ b/decisiones.md
@@ -5,3 +5,11 @@
 - Se estableció `main` como rama principal por convención moderna.
 - Se configuró VSCode como editor por comodidad (`core.editor = code --wait`).
 
+
+## Desarrollo de la funcionalidad
+- Se creó la rama `feature/mi-funcionalidad` para aislar el trabajo de `main`.
+- Commit 1: `feat(linecount): agrega script para contar líneas`.  
+  👉 Commit atómico: solo introduce la funcionalidad mínima.
+- Commit 2: `docs(linecount): documenta ejemplo en README`.  
+  👉 Commit separado: documentación no mezclada con código.
+- Justificación: mantener cambios claros, fáciles de revisar o revertir.

--- a/decisiones.md
+++ b/decisiones.md
@@ -13,3 +13,10 @@
 - Commit 2: `docs(linecount): documenta ejemplo en README`.  
   👉 Commit separado: documentación no mezclada con código.
 - Justificación: mantener cambios claros, fáciles de revisar o revertir.
+## Hotfix en producción y propagación
+- Bug simulado en `main`: commit con texto erróneo en README.
+- Hotfix: rama `hotfix/readme-bug`, commit de corrección.
+- Integración a `main`: `git merge --no-ff` → deja registro explícito del hotfix.
+- Propagación a `feature/mi-funcionalidad`: `git cherry-pick <hash>` del fix.
+- Justificación: cherry-pick me permitió traer solo el fix sin arrastrar otros cambios de `main`.
+

--- a/scripts/linecount.sh
+++ b/scripts/linecount.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+# Cuenta líneas de un archivo de texto.
+# Uso: ./scripts/linecount.sh archivo.txt
+
+set -euo pipefail
+file="${1:-}"
+if [[ -z "$file" || ! -f "$file" ]]; then
+  echo "Uso: $0 <archivo.txt>" >&2
+  exit 1
+fi
+wc -l "$file"


### PR DESCRIPTION
- Agrega script scripts/linecount.sh para contar líneas (commit atómico de funcionalidad).
- Documenta ejemplo de uso en README (commit atómico de docs).
- Hotfix de README previamente aplicado a main y propagado a la feature por cherry-pick.
- Decisiones y justificación en decisiones.md.
